### PR TITLE
Make static directory optional

### DIFF
--- a/atlas.lidar.io.toml
+++ b/atlas.lidar.io.toml
@@ -1,8 +1,8 @@
 [server]
 ip = "127.0.0.1"
 port = 3000
-static_directory = "/var/www/atlas.lidar.io/static"
 template_directory = "/var/www/atlas.lidar.io/templates"
+# no static directory, since we serve static files through Apache
 
 [heartbeat]
 directory = "/var/iridium"

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,7 +56,7 @@ impl Config {
 pub struct Server {
     pub ip: String,
     pub port: u16,
-    pub static_directory: String,
+    pub static_directory: Option<String>,
     pub template_directory: String,
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -49,7 +49,9 @@ impl Server {
         let addr = SocketAddr::new(ip, config.port);
 
         let mut mount = Mount::new();
-        mount.mount("/static/", Static::new(&config.static_directory));
+        if let Some(static_directory) = config.static_directory {
+            mount.mount("/static/", Static::new(&static_directory));
+        }
         mount.mount("/api/v1/", Api::new(world.clone()));
         mount.mount("/gif/", Gif::new(world.clone()));
         mount.mount("/", Index::new(world.clone()));


### PR DESCRIPTION
This allows us to *not* map the static directory through the rust
server, assuming that the upstream server takes care of the static
images.

Fixes #4 (along with some server config changes).