### PR TITLE
Show aborted scans

### DIFF
--- a/src/helper.rs
+++ b/src/helper.rs
@@ -120,6 +120,32 @@ pub fn efoy(_: &Context,
     Ok(())
 }
 
+pub fn last_scan_detail(_: &Context,
+                        h: &Helper,
+                        handlebars: &Handlebars,
+                        rc: &mut RenderContext)
+                        -> Result<(), RenderError> {
+    if let Some(scan) = h.param(0).and_then(|p| p.value().as_object()) {
+        // TODO factor out parsing these strings
+        let start = UTC.datetime_from_str(scan.get("start").unwrap().as_string().unwrap(),
+                               "%Y-%m-%d %H:%M:%S UTC")
+            .unwrap();
+        let end = UTC.datetime_from_str(scan.get("end").unwrap().as_string().unwrap(),
+                               "%Y-%m-%d %H:%M:%S UTC")
+            .unwrap();
+        if end < start {
+            try!(write!(rc.writer,
+                        "{}",
+                        try!(handlebars.render("last-scan-abort", scan))));
+        } else {
+            try!(write!(rc.writer,
+                        "{}",
+                        try!(handlebars.render("last-scan-ok", scan))));
+        }
+    }
+    Ok(())
+}
+
 mod utils {
     pub fn commas(n: u64) -> String {
         let mut bytes = n.to_string().into_bytes();

--- a/src/server.rs
+++ b/src/server.rs
@@ -74,6 +74,7 @@ impl Server {
                                          yellow_floor: 50.,
                                      }));
             registry.register_helper("efoy", Box::new(helper::efoy));
+            registry.register_helper("last_scan_detail", Box::new(helper::last_scan_detail));
         }
         chain.link_after(maybe_watch_handlebars_engine(&config.template_directory,
                                                        handlebars_engine));

--- a/static/atlas.lidar.io.css
+++ b/static/atlas.lidar.io.css
@@ -37,6 +37,10 @@ body {
   background-color: #ccc;
 }
 
+.status-report li.status-report-aborted {
+  background-color: #f2dede;
+}
+
 .status-report .glyphicon {
   margin-top: 5px;
   margin-bottom: 10px;

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -73,16 +73,7 @@
         <div class="col-xs-12 col-md-4">
           <h2>Last scan</h2>
 
-          <dl>
-            <dt>Start time</dt>
-            <dd>{{last_scan.start}}</dd>
-
-            <dt>End time</dt>
-            <dd>{{last_scan.end}}</dd>
-
-            <dt>Number of points</dt>
-            <dd>{{commas last_scan.detail.num_points}}</dd>
-          </dl>
+          {{last_scan_detail last_scan}}
         </div>
         {{/with}}
       </div>

--- a/templates/last-scan-abort.hbs
+++ b/templates/last-scan-abort.hbs
@@ -1,0 +1,5 @@
+<div class="alert alert-danger">
+  The last scan was aborted mid-scan for unknown reasons.
+  The scan started at {{start}}.
+</div>
+

--- a/templates/last-scan-ok.hbs
+++ b/templates/last-scan-ok.hbs
@@ -1,0 +1,10 @@
+<dl>
+  <dt>Start time</dt>
+  <dd>{{start}}</dd>
+
+  <dt>End time</dt>
+  <dd>{{end}}</dd>
+
+  <dt>Number of points</dt>
+  <dd>{{commas detail.num_points}}</dd>
+</dl>


### PR DESCRIPTION
Aborted scans start but never finish. Two website changes:

1. Add a red warning message to the last scan section w/ a message that things were aborted and the time the scan started.
2. Make the top status block red and flag it w/ aborted.